### PR TITLE
FIX: Workaround for header imports (of GoogleUtilities) in Firebase

### DIFF
--- a/Sources/Core/Extensions/SwiftPM.swift
+++ b/Sources/Core/Extensions/SwiftPM.swift
@@ -6,6 +6,7 @@ import TSCBasic
 import struct TSCUtility.Version
 
 package typealias AbsolutePath = Basics.AbsolutePath
+package typealias RelativePath = Basics.RelativePath
 
 extension URL {
   func subPaths() throws -> [URL] {
@@ -207,9 +208,8 @@ extension TargetDescription {
     )
   }
 
-  var srcPath: String {
-    path ?? "\(type.defaultSrcRoot)/\(name)"
-  }
+  var srcPath: String { path ?? "\(type.defaultSrcRoot)/\(name)" }
+  var xccacheSrcPath: String { "xccache.src/\(srcPath)" }
 }
 
 extension TargetDescription.TargetKind {
@@ -293,6 +293,15 @@ extension ModulesGraph {
     case .target:
       return nil
     }
+  }
+
+  var rootModules: [ResolvedModule] { rootPackages.flatMap(\.modules) }
+
+  func recursiveModulesFromRoot(excludeMacroDeps: Bool = false) throws -> [ResolvedModule] {
+    try rootPackages
+      .flatMap(\.modules)
+      .flatMap { try $0.recursiveModules(excludeMacroDeps: excludeMacroDeps) }
+      .unique()
   }
 
   func recursiveModules(

--- a/Sources/Core/Generator/GraphGenerator.swift
+++ b/Sources/Core/Generator/GraphGenerator.swift
@@ -24,12 +24,11 @@ final class GraphGenerator {
     }
     let fullName: (ResolvedModule) -> String = { shortNameToFullName[$0.name] ?? $0.name }
 
-    let rootModules = graph.rootPackages.flatMap(\.modules)
-    let modules = try rootModules.flatMap { try $0.recursiveModules(excludeMacroDeps: true) }.unique()
+    let modules = try graph.recursiveModulesFromRoot(excludeMacroDeps: true)
     let directDeps = try modules.toDictionary { m in
       try (fullName(m), m.directModules(excludeMacroDeps: true).map(fullName))
     }
-    let macros = try rootModules.toDictionary { m in
+    let macros = try graph.rootModules.toDictionary { m in
       let paths = try m.recursiveModules(excludeMacroDeps: true)
         .compactMap { d in cache.binaryPath(for: d.name, ext: "macro") }
         .map(\.pathString)

--- a/Sources/Core/Proxy/ProxyPackage.swift
+++ b/Sources/Core/Proxy/ProxyPackage.swift
@@ -37,6 +37,9 @@ struct ProxyPackage: ProxyPackageProtocol {
     )
     try pkgDir.appending("xccache.src").symlink(to: bare.path)
 
+    // Symlink to root's headers which expose... all headers
+    try xccacheHeadersPath.symlink(to: proxiesDir.appending(relative: "../.headers"))
+
     // NOTE: This is a workaround to make dirs in a bare package show up in Xcode.
     // It's very strange that sometimes Xcode only displays the manifest for this case.
     // Here, we're creating symlinks to files/folders under the bare package.
@@ -69,7 +72,7 @@ struct ProxyPackage: ProxyPackageProtocol {
       return try .init(name: this.name, path: relativePath.pathString, type: .binary)
     }
     return try this.withChanges(
-      path: "xccache.src/\(this.srcPath)",
+      path: this.xccacheSrcPath,
       dependencies: recursiveTargetDependencies(for: this),
       settings: buildSettings(for: this),
     )

--- a/Sources/Core/Proxy/RootProxyPackage.swift
+++ b/Sources/Core/Proxy/RootProxyPackage.swift
@@ -28,6 +28,7 @@ struct RootProxyPackage: ProxyPackageProtocol {
       products: reachableProducts(),
       targets: reachableTargets().map(convert(_:)),
     )
+    try exposeHeaders()
     try pkgDir.appending(".Sources").symlink(to: bare.path.appending(".Sources"))
     try proxy.write(to: pkgDir.appending("Package.swift"))
 
@@ -35,10 +36,43 @@ struct RootProxyPackage: ProxyPackageProtocol {
     try pkgDir.appending("binaries").symlink(to: cache.dir)
   }
 
+  private func exposeHeaders() throws {
+    // Here, we expose all headers so that if building from sources, it's very less likly to fail.
+    // Header resolution in xcframeworks and in swift packages' bare/source forms behaves differently.
+    //
+    // While `#import <GoogleUtilities/GULAppEnvironmentUtil.h>` works in the bare form, `GoogleUtilities` is not a module.
+    // The actual module it belongs to is `GoogleUtilities_Environment`.
+    // This kind of import is valid in the bare form as long as it's visible to SPM search paths.
+    // Yet, it's broken if `GoogleUtilities_Environment` is in binary.
+    // To tackle this issue, we expose all headers, just like how they are visible to the SPM header resolution system.
+    // --------------------------------------------------------------------------------------------------------
+    // For every public header, we create a symlink that preserves the relative structure (from the include dir)
+    //
+    //   include / -- Foo / -- foo1.h     |     .headers / -- Foo / -- foo1.h
+    //            |         -- foo2.h     |               |         -- foo2.h
+    //            |-- Bar / -- bar1.h     |               |-- Bar / -- bar1.h
+    //
+    // This enables `#import <Foo/foo1.h>`, `#import <Bar/bar1.h>`
+    // --------------------------------------------------------------------------------------------------------
+    let headersDir = try pkgDir.appending(".headers").recreate()
+    let clangModules = try graph.recursiveModulesFromRoot(excludeMacroDeps: true).compactMap { $0.underlying as? ClangModule }
+    try clangModules.forEach { m in
+      try m.headersUnderIncludeDir().forEach { p in
+        try headersDir.appending(p.relative(to: m.includeDir)).symlink(to: p)
+      }
+    }
+  }
+
   private func convert(_ this: TargetDescription) throws -> TargetDescription {
     try this.withChanges(
       dependencies: recursiveTargetDependencies(for: this),
       settings: buildSettings(for: this),
     )
+  }
+}
+
+private extension ClangModule {
+  func headersUnderIncludeDir() -> [AbsolutePath] {
+    headers.filter { $0.isDescendantOfOrEqual(to: includeDir) }
   }
 }


### PR DESCRIPTION
### Problem

In Firebase code, there are header imports like `#import <GoogleUtilities/GULAppEnvironmentUtil.h>`.
This is a cross-module import, assuming GoogleUtilities is the container module. However, there's no such a `GoogleUtilities` module. The host module is actually `GoogleUtilities-Environment`
The reason why this import is valid in the bare form (building from source) is that the header is visible to the search path, ie. there's a `GoogleUtilities` dri under the search path containing the header.
And ofc, it doesn't work when `GoogleUtilities-Environment` becomes binary.

### Solution

We expose all public headers to a `xccache.headers` dir in the root proxy package. Those headers are placed in a way that preserves the structure (relatively to the include dirs).
This is similar to SPM header resolution system works.

```
   include / -- Foo / -- foo1.h     |     .headers / -- Foo / -- foo1.h
            |         -- foo2.h     |               |         -- foo2.h
            |-- Bar / -- bar1.h     |               |-- Bar / -- bar1.h

```